### PR TITLE
Fix documentation on MAIL_URL value (#8805)

### DIFF
--- a/History.md
+++ b/History.md
@@ -183,9 +183,11 @@
 
     > Note: The `MAIL_URL` should be configured with a scheme which matches the
     > protocol desired by your e-mail vendor/mail-transport agent.  For
-    > encrypted connections (typically listening on port 465 or 587), this means
-    > using `smtps://`.  Unencrypted connections should continue to use
-    > `smtp://`.
+    > encrypted connections (typically listening on port 465), this means
+    > using `smtps://`.  Unencrypted connections or those secured through
+    > a `STARTTLS` connection upgrade (typically using port 587 and sometimes
+    > port 25) should continue to use `smtp://`.  TLS/SSL will be automatically
+    > enabled if the mail provider supports it.
 
 * A new `Tracker.inFlush()` has been added to provide a global Tracker
   "flushing" state.


### PR DESCRIPTION
* Fix documentation on MAIL_URL value

See https://github.com/meteor/meteor/issues/8804

* Fix long-lines for History.md.

This file is kept word-wrapped. :)

* Additional clarification.

E-mail protocols are far too confusing.

I will squash this commit.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first (in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests/issues) repository) and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/meteor/meteor/blob/devel/Contributing.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
