### PR TITLE
Avoid api.export("process") in modules package.js.

### DIFF
--- a/packages/modules/package.js
+++ b/packages/modules/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: "modules",
-  version: "0.9.2",
+  version: "0.9.4",
   summary: "CommonJS module system",
   documentation: "README.md"
 });
@@ -14,5 +14,4 @@ Package.onUse(function(api) {
   api.mainModule("client.js", "client");
   api.mainModule("server.js", "server");
   api.export("meteorInstall");
-  api.export("process");
 });

--- a/packages/modules/process.js
+++ b/packages/modules/process.js
@@ -1,32 +1,36 @@
-try {
-  // The application can run `npm install process` to provide its own
-  // process stub; otherwise this module will provide a partial stub.
-  process = global.process || require("process");
-} catch (noProcess) {
-  process = {};
+if (! global.process) {
+  try {
+    // The application can run `npm install process` to provide its own
+    // process stub; otherwise this module will provide a partial stub.
+    global.process = require("process");
+  } catch (missing) {
+    global.process = {};
+  }
 }
+
+var proc = global.process;
 
 if (Meteor.isServer) {
   // Make require("process") work on the server in all versions of Node.
   meteorInstall({
     node_modules: {
       "process.js": function (r, e, module) {
-        module.exports = process;
+        module.exports = proc;
       }
     }
   });
 } else {
-  process.platform = "browser";
-  process.nextTick = process.nextTick || Meteor._setImmediate;
+  proc.platform = "browser";
+  proc.nextTick = proc.nextTick || Meteor._setImmediate;
 }
 
-if (typeof process.env !== "object") {
-  process.env = {};
+if (typeof proc.env !== "object") {
+  proc.env = {};
 }
 
 var hasOwn = Object.prototype.hasOwnProperty;
 for (var key in meteorEnv) {
   if (hasOwn.call(meteorEnv, key)) {
-    process.env[key] = meteorEnv[key];
+    proc.env[key] = meteorEnv[key];
   }
 }


### PR DESCRIPTION
Declaring a package-local variable called `process` in the `modules`
package causes uglify-js not to replace `process.env.NODE_ENV` with a
string literal value in any `node_modules` contained by the `modules`
package, which causes React Dev Tools to display a warning.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first (in the [meteor/meteor-feature-requests](https://github.com/meteor/meteor-feature-requests/issues) repository) and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/meteor/meteor/blob/devel/Contributing.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.
